### PR TITLE
fix(pipelines): add pipeline to key path on input

### DIFF
--- a/pipelines/enforce-github-secrets-trigger.rego
+++ b/pipelines/enforce-github-secrets-trigger.rego
@@ -9,7 +9,7 @@ package spinnaker.execution.pipelines.before
 
 deny["Every pipeline github trigger must have a secret"] {
 	some i
-    trigger := input.triggers[i]
+    trigger := input.pipeline.triggers[i]
 	trigger.type == "git"
     trigger.source == "github"
     object.get(trigger, "secret", "") == ""


### PR DESCRIPTION
Policy Engine provides the contents of the pipeline configuration on the key `pipeline`. This was neglected when writing the policy.