### PR TITLE
chore(tasks): add task policy example

### DIFF
--- a/tasks/enfore-stage-success.rego
+++ b/tasks/enfore-stage-success.rego
@@ -1,0 +1,7 @@
+package spinnaker.execution.task.before.deployManifest
+
+deny["deployManifest cannot be run without requisite canDeploy stage"] {
+    canDeployStages := [s | s = input.pipeline.stages[_]; s.type == "customCanDeployStage"]
+    stage := canDeployStages[_]
+    not stage.context.canDeploy == true
+}

--- a/tasks/enfore-stage-success_test.rego
+++ b/tasks/enfore-stage-success_test.rego
@@ -1,0 +1,39 @@
+package spinnaker.execution.task.before.deployManifest
+
+test_denied_if_pipeline_does_not_pass_approval_stage {
+    deny["deployManifest cannot be run without requisite canDeploy stage"] with input as {
+        "task": {},
+        "pipeline": {
+            "stages": [
+                {
+                    "type": "customCanDeployStage",
+                    "context": {
+                        "canDeploy": false
+                    }
+                },
+                {
+                    "type": "wait",
+                }
+            ]
+        }
+    }
+}
+
+test_not_denied_if_pipeline_passes_approval_stage {
+    deny with input as {
+        "task": {},
+        "pipeline": {
+            "stages": [
+                {
+                    "type": "customCanDeployStage",
+                    "context": {
+                        "canDeploy": true
+                    }
+                },
+                {
+                    "type": "wait",
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
adds a task policy example for deployManifest that will block the task
if there hasn't been a prerequisite stage check