### PR TITLE
chore(rbac): add rbac examples for gate plugin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: Test Policies
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    name: Test All Policies
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Codebase
+      uses: actions/checkout@v2
+    - name: Test Policies
+      uses: petroprotsakh/opa-test-action@v2.1
+
+    

--- a/rbac/rbac-example.rego
+++ b/rbac/rbac-example.rego
@@ -1,0 +1,75 @@
+# the spinnaker.http.authz package is uses by gate
+# to make authorization decisions about incoming
+# API calls
+package spinnaker.http.authz
+
+# by default, nothing is allowed
+default allow = false
+
+# fiat admins are allowed to do everything
+allow {
+    input.user.isAdmin == true
+}
+
+
+# deploy_read can only get and list applications
+allow {
+    input.method = "GET"
+    input.path[_] = "applications"
+    input.user.roles[_] = "deploy_read"
+}
+
+# deploy_admin is allowed to edit and delete pipelines
+allow {
+    ["GET", "POST", "DELETE"][_] = input.method
+    input.path[0] = "pipelines"
+    input.user.roles[_] = "deploy_admin"
+}
+
+# deploy_execute_dev can perform actions on dev accounts from the infra tab
+allow {
+    input.method = "POST"
+    input.path[0] = "tasks"
+
+    job := input.body.job[0]
+
+    # have to make a list of all actions you can take from the infra tab here
+    ["scaleManifest", "deployManifest"][_] = job.type
+    
+    # this check depends on how accounts are names. you may have to use regular expression
+    # to match accounts who names end in dev, for example. 
+    job.account = "dev"
+    input.user.roles[_] = "deploy_execute_dev"
+}
+
+# deploy_execute_test can perform actions on dev accounts from the infra tab
+allow {
+    input.method = "POST"
+    input.path[0] = "tasks"
+
+    job := input.body.job[0]
+
+    # have to make a list of all actions you can take from the infra tab here
+    ["scaleManifest", "deployManifest"][_] = job.type
+    
+    # this check depends on how accounts are names. you may have to use regular expression
+    # to match accounts who names end in test, for example. 
+    job.account = "test"
+    input.user.roles[_] = "deploy_execute_test"
+}
+
+# deploy_execute_prod can perform actions on dev accounts from the infra tab
+allow {
+    input.method = "POST"
+    input.path[0] = "tasks"
+
+    job := input.body.job[0]
+    
+    # have to make a list of all actions you can take from the infra tab here.
+    ["scaleManifest", "deployManifest"][_] = job.type
+    
+    # this check depends on how accounts are names. you may have to use regular expression
+    # to match accounts who names end in prod, for example. 
+    job.account = "prod"
+    input.user.roles[_] = "deploy_execute_prod"
+}

--- a/rbac/rbac-example_test.rego
+++ b/rbac/rbac-example_test.rego
@@ -1,0 +1,134 @@
+package spinnaker.http.authz
+
+test_is_allowed_if_user_is_admin {
+    allow with input as {
+        "user": {
+            "isAdmin": true
+        }
+    }
+}
+
+test_not_allowed_if_user_is_not_admin {
+    not allow with input as {
+        "user": {
+            "isAdmin": false
+        }
+    }
+}
+
+test_get_application_allowed_by_deploy_read {
+    allow with input as {
+        "user": {
+            "isAdmin": false,
+            "roles": ["deploy_read"]
+        },
+        "path": ["applications", "myapp"],
+        "method": "GET"
+    }
+}
+
+test_get_application_not_allowed_by_deploy_admin {
+    not allow with input as {
+        "user": {
+            "isAdmin": false,
+            "roles": ["deploy_admin"]
+        },
+        "path": ["applications", "myapp"],
+        "method": "GET"
+    }
+}
+
+test_list_applications_allowed_by_deploy_read {
+    allow with input as {
+        "user": {
+            "isAdmin": false,
+            "roles": ["deploy_read"]
+        },
+        "path": ["applications"],
+        "method": "GET"
+    }
+}
+
+test_list_applications_not_allowed_by_deploy_admin {
+    not allow with input as {
+        "user": {
+            "isAdmin": false,
+            "roles": ["deploy_admin"]
+        },
+        "path": ["applications"],
+        "method": "GET"
+    }
+}
+
+test_deploy_admin_is_allowed_to_delete_pipelines {
+    allow with input as {
+        "user": {
+            "isAdmin": false,
+            "roles": ["deploy_admin"]
+        },
+        "method": "DELETE",
+        "path": ["pipelines", "testapp", "testpipeline"]
+    }
+}
+
+test_deploy_admin_is_allowed_to_create_and_update_pipelines {
+    allow with input as {
+        "user": {
+            "isAdmin": false,
+            "roles": ["deploy_admin"]
+        },
+        "method": "POST",
+        "path": ["pipelines", "testapp", "testpipeline"]
+    }
+}
+
+test_deploy_execute_test_can_scale_manifests_from_infra_tab {
+    allow with input as {
+        "user": {
+            "isAdmin": false,
+            "roles": ["deploy_execute_test"]
+        },
+        "method": "POST",
+        "path": ["tasks"],
+        "body": {
+            "job": [{
+                "type": "scaleManifest",
+                "account": "test"
+            }]
+        }
+    }
+}
+
+test_deploy_execute_test_cannot_scale_manifests_from_infra_tab_for_prod_account {
+    not allow with input as {
+        "user": {
+            "isAdmin": false,
+            "roles": ["deploy_execute_test"]
+        },
+        "method": "POST",
+        "path": ["tasks"],
+        "body": {
+            "job": [{
+                "type": "scaleManifest",
+                "account": "prod"
+            }]
+        }
+    }
+}
+
+test_deploy_execute_test_cannot_delete_manifests_from_infra_tab_for_prod_account {
+    not allow with input as {
+        "user": {
+            "isAdmin": false,
+            "roles": ["deploy_execute_test"]
+        },
+        "method": "POST",
+        "path": ["tasks"],
+        "body": {
+            "job": [{
+                "type": "deleteManifest",
+                "account": "test"
+            }]
+        }
+    }
+}


### PR DESCRIPTION
adds example rbac policies for the upcoming gate extension of policy
engine. tests are included!